### PR TITLE
Fix for issue #205 "Phoenix crashes after playing through a certain number of levels"

### DIFF
--- a/src/init.asm
+++ b/src/init.asm
@@ -73,7 +73,8 @@ smc_loader_jump:
 loader_table:
     ret                          ;0
     kjp(shop)                    ;1
-    jr level_loader \ nop \ nop  ;jp game_finished           ;1
+    ;jr level_loader \ nop \ nop  ;jp game_finished           ;1
+    jp game_finished \ nop       ;4 ;NOTE: Not sure why but the jump vector to the game_finished function was commented out, and jr level_loader was placed there instead? I put back the game_finished vector so the game shouldn't crash upon completion now.
     kjp(set_power)               ;7
     kjp(set_movetype)            ;10
     kjp(set_movedata)            ;13


### PR DESCRIPTION
On line 76 of init.asm I found that the jump vector for the game_finished function was commented out and in its place jr level_loader was there instead. I'm assuming this is what's causing that crashing behavior as when the game attempts to finish it instead just jumps to the level_loader function again causing erronious behavior. I have put the jump vector back as well as padding it with a nop to make it the required 4 bytes size. Now the game should exit correctly.